### PR TITLE
Feature/Image Downloader Receipt Handling

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		02D0E3AD633CCC9A7C48642A44B66DC0 /* ImageDownloaderReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2938AE5A01C87658689FB92497EB7105 /* ImageDownloaderReceipt.swift */; };
 		076B39E87F4A642B18763D39BF326B2D /* Pods-OKImageDownloader_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = EDBB407516D17EB154D4B95C9BB34B23 /* Pods-OKImageDownloader_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		17012A0E21821F5000A6DE75 /* ImageDownloaderReceiptHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17012A0D21821F5000A6DE75 /* ImageDownloaderReceiptHandling.swift */; };
 		176CC1CB215304F000F7B862 /* APIUrlLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176CC1CA215304F000F7B862 /* APIUrlLoader.swift */; };
 		176CC1CE21530CD400F7B862 /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176CC1CD21530CD400F7B862 /* APIRequest.swift */; };
 		176CC1D021530D7100F7B862 /* ImageDownloaderRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176CC1CF21530D7100F7B862 /* ImageDownloaderRequest.swift */; };
@@ -49,6 +50,7 @@
 
 /* Begin PBXFileReference section */
 		1069444B5530E3DBBBB333A4D157A092 /* Pods_OKImageDownloader_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OKImageDownloader_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		17012A0D21821F5000A6DE75 /* ImageDownloaderReceiptHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloaderReceiptHandling.swift; sourceTree = "<group>"; };
 		17199839976578ABF9F1DCE86871044E /* Pods-OKImageDownloader_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-OKImageDownloader_Example-frameworks.sh"; sourceTree = "<group>"; };
 		176CC1CA215304F000F7B862 /* APIUrlLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIUrlLoader.swift; sourceTree = "<group>"; };
 		176CC1CD21530CD400F7B862 /* APIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 			children = (
 				176CC1CD21530CD400F7B862 /* APIRequest.swift */,
 				177C3C75217E857100727838 /* ImageDownloading.swift */,
+				17012A0D21821F5000A6DE75 /* ImageDownloaderReceiptHandling.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -437,6 +440,7 @@
 				833BB7A8B14F6FB186E148344FD751E8 /* ImageDownloaderError.swift in Sources */,
 				176CC1D021530D7100F7B862 /* ImageDownloaderRequest.swift in Sources */,
 				02D0E3AD633CCC9A7C48642A44B66DC0 /* ImageDownloaderReceipt.swift in Sources */,
+				17012A0E21821F5000A6DE75 /* ImageDownloaderReceiptHandling.swift in Sources */,
 				9A4C917BF32E1C794BB1A770838F7AA7 /* Int+FileSizeConverter.swift in Sources */,
 				177C3C76217E857100727838 /* ImageDownloading.swift in Sources */,
 				A0DF4808F4B715F34AB96D607499BED9 /* OKImageDownloader-dummy.m in Sources */,

--- a/Example/Tests/ImageDownloaderTests.swift
+++ b/Example/Tests/ImageDownloaderTests.swift
@@ -281,10 +281,12 @@ final class ImageDownloaderTests: XCTestCase {
                 XCTFail()
             }
         }
+        let imageViewOne = UIImageView()
+        let imageViewTwo = UIImageView()
         
-        let receiptToCancel = imageDownloader.download(url: url, completionHandler: firstCompletionHandler)
-        imageDownloader.download(url: url, completionHandler: secondCompletionHandler)
-        imageDownloader.cancel(url: url, receipt: receiptToCancel)
+        imageDownloader.download(url: url, receiptHandler: imageViewOne, completionHandler: firstCompletionHandler)
+        imageDownloader.download(url: url, receiptHandler: imageViewTwo, completionHandler: secondCompletionHandler)
+        imageDownloader.cancel(url: url, receipt: imageViewOne.imageDownloaderReceipt)
         
         wait(for: [expectation], timeout: 2)
     }

--- a/Example/Tests/UIImageViewImageDownloaderTests.swift
+++ b/Example/Tests/UIImageViewImageDownloaderTests.swift
@@ -118,7 +118,6 @@ final class UIImageViewImageDownloaderTests: XCTestCase {
     }
     
     func test_downloadImage_whenFailureAndNoCompletionHandler_itDoesNotSetTheImage() {
-                
         imageView.downloadImage(with: url, imageDownloader: imageDownloader, completionHandler: nil)
         
         XCTAssertNil(imageView.image)

--- a/OKImageDownloader.podspec
+++ b/OKImageDownloader.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'OKImageDownloader'
-  s.version          = '0.2.0'
+  s.version          = '0.3.0'
   s.summary          = 'Image downloading made easy'
   s.description      = 'A simple framework to manage the downloading, decompressing, caching and cancelling of images.'
   s.homepage         = 'https://github.com/okcupid/OKImageDownloader'

--- a/OKImageDownloader/Classes/API/ImageDownloader.swift
+++ b/OKImageDownloader/Classes/API/ImageDownloader.swift
@@ -71,7 +71,6 @@ public final class ImageDownloader: ImageDownloading {
     
     public func download(url: URL, receiptHandler: ImageDownloaderReceiptHandling? = nil, completionHandler: @escaping CompletionHandler) {
         let receipt = ImageDownloaderReceipt(id: UUID(), url: url)
-        var receiptHandler = receiptHandler
         receiptHandler?.imageDownloaderReceipt = receipt
         
         synchronizationQueue.sync {

--- a/OKImageDownloader/Classes/API/ImageDownloader.swift
+++ b/OKImageDownloader/Classes/API/ImageDownloader.swift
@@ -69,9 +69,10 @@ public final class ImageDownloader: ImageDownloading {
     
     // MARK: - Downloading
     
-    @discardableResult
-    public func download(url: URL, completionHandler: @escaping CompletionHandler) -> ImageDownloaderReceipt {
+    public func download(url: URL, receiptHandler: ImageDownloaderReceiptHandling? = nil, completionHandler: @escaping CompletionHandler) {
         let receipt = ImageDownloaderReceipt(id: UUID(), url: url)
+        var receiptHandler = receiptHandler
+        receiptHandler?.imageDownloaderReceipt = receipt
         
         synchronizationQueue.sync {
             guard !checkForImageInCacheAndCompleteIfNeeded(with: url, receipt: receipt, completionHandler: completionHandler) else {
@@ -92,8 +93,6 @@ public final class ImageDownloader: ImageDownloading {
                 self.processSuccessfulResponse(url: url, image: image, error: error)
             } 
         }
-        
-        return receipt
     }
     
     // MARK: - Cancelling

--- a/OKImageDownloader/Classes/Extensions/UIImageView+ImageDownloader.swift
+++ b/OKImageDownloader/Classes/Extensions/UIImageView+ImageDownloader.swift
@@ -28,8 +28,7 @@ public extension UIImageView {
     }
     
     public func downloadImage(with url: URL, imageDownloader: ImageDownloading = ImageDownloader.shared, completionHandler: ImageDownloader.CompletionHandler?) {
-        imageDownloaderReceipt = imageDownloader.download(url: url) { dataResponse, downloadReceipt in
-         
+        imageDownloader.download(url: url, receiptHandler: self) { dataResponse, downloadReceipt in
             guard let completionHandler = completionHandler else {
                 switch dataResponse {
                 case let .success(image):
@@ -59,3 +58,5 @@ public extension UIImageView {
     }
     
 }
+
+extension UIImageView: ImageDownloaderReceiptHandling {}

--- a/OKImageDownloader/Classes/Protocols/ImageDownloaderReceiptHandling.swift
+++ b/OKImageDownloader/Classes/Protocols/ImageDownloaderReceiptHandling.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-public protocol ImageDownloaderReceiptHandling {
+public protocol ImageDownloaderReceiptHandling: class {
     var imageDownloaderReceipt: ImageDownloaderReceipt? { get set }
 }

--- a/OKImageDownloader/Classes/Protocols/ImageDownloaderReceiptHandling.swift
+++ b/OKImageDownloader/Classes/Protocols/ImageDownloaderReceiptHandling.swift
@@ -1,0 +1,12 @@
+//
+//  ImageDownloaderReceiptHandling.swift
+//  OKImageDownloader
+//
+//  Created by Jordan Guggenheim on 10/25/18.
+//
+
+import Foundation
+
+public protocol ImageDownloaderReceiptHandling {
+    var imageDownloaderReceipt: ImageDownloaderReceipt? { get set }
+}

--- a/OKImageDownloader/Classes/Protocols/ImageDownloading.swift
+++ b/OKImageDownloader/Classes/Protocols/ImageDownloading.swift
@@ -12,8 +12,7 @@ public protocol ImageDownloading: class {
     var urlCache: URLCache { get }
     var urlSessionConfiguration: URLSessionConfiguration { get }
     
-    @discardableResult
-    func download(url: URL, completionHandler: @escaping ImageDownloader.CompletionHandler) -> ImageDownloaderReceipt
+    func download(url: URL, receiptHandler: ImageDownloaderReceiptHandling?, completionHandler: @escaping ImageDownloader.CompletionHandler)
     
     func cancel(url: URL, receipt: ImageDownloaderReceipt?)
 }


### PR DESCRIPTION
Add ImageDownloaderReceiptHandling protocol to support setting the receipt before the completion is called in synchronous scenarios. In our case for unit testing.