### PR TITLE
Update UIImageView and UIButton Extensions Method Names + Assert Logic

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -15,7 +15,7 @@ final class ViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        imageView.ok.downloadImage(with: URL(string: "https://www.gstatic.com/webp/gallery/4.webp")!)
+        imageView.ok.setImage(with: URL(string: "https://www.gstatic.com/webp/gallery/4.webp")!)
     }
 }
 

--- a/Sources/Extensions/UIButton+ImageDownloader.swift
+++ b/Sources/Extensions/UIButton+ImageDownloader.swift
@@ -10,13 +10,17 @@ import UIKit
 
 public extension ObjectWrapper where T: UIButton {
     
-    func downloadImage(with url: URL,
-                       for state: UIControl.State = .normal,
-                       imageDownloader: ImageDownloading = ImageDownloader.shared,
-                       completionHandler: ImageDownloader.CompletionHandler? = nil) {
-        cancelImageDownload(imageDownloader: imageDownloader)
+    func setImage(with url: URL,
+                  for state: UIControl.State = .normal,
+                  imageDownloader: ImageDownloading = ImageDownloader.shared,
+                  completionHandler: ImageDownloader.CompletionHandler? = nil) {
+        if imageDownloaderReceipt != nil {
+            assertionFailure("Active Download In Progress, Cancel Before Starting a New Request")
+        }
         
         imageDownloader.download(url: url, receiptHandler: self) { result, downloadReceipt in
+            self.imageDownloaderReceipt = nil
+
             guard let completionHandler = completionHandler else {
                 switch result {
                 case .success(let image):

--- a/Sources/Extensions/UIImageView+ImageDownloader.swift
+++ b/Sources/Extensions/UIImageView+ImageDownloader.swift
@@ -10,12 +10,16 @@ import UIKit
 
 public extension ObjectWrapper where T: UIImageView {
     
-    func downloadImage(with url: URL,
-                       imageDownloader: ImageDownloading = ImageDownloader.shared,
-                       completionHandler: ImageDownloader.CompletionHandler? = nil) {
-        cancelImageDownload(imageDownloader: imageDownloader)
+    func setImage(with url: URL,
+                  imageDownloader: ImageDownloading = ImageDownloader.shared,
+                  completionHandler: ImageDownloader.CompletionHandler? = nil) {
+        if imageDownloaderReceipt != nil {
+            assertionFailure("Active Download In Progress, Cancel Before Starting a New Request")
+        }
         
         imageDownloader.download(url: url, receiptHandler: self) { result, downloadReceipt in
+            self.imageDownloaderReceipt = nil
+            
             guard let completionHandler = completionHandler else {
                 switch result {
                 case .success(let image):


### PR DESCRIPTION
To more clearly describe that the image may not be downloaded, rename to setImage. 

Also remove the side effect of cancelling a download on setImage.